### PR TITLE
Update module for Foundry VTT v14 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,20 @@ The WLED page explains the exact hardware installation better than I could here,
 Once you have the hardware ready, all you need is the IP address of the WLED controller and you can continue.
 
 ## Installation
-1. Clone or download this repository into the `modules` directory of your Foundry VTT installation.
-   git clone https://github.com/mcules/FoundryVTT-digitable-initiative-led
+
+### Recommended: install via manifest URL
+1. In Foundry's setup screen open **Add-on Modules → Install Module**.
+2. Paste this manifest URL into the **Manifest URL** field at the bottom and click **Install**:
+   ```
+   https://github.com/b34rblack-glitch/FoundryVTT-digitable-initiative-led/raw/claude/foundry-vtt-v14-update-HsRfq/module.json
+   ```
+3. Enable the module inside your world from **Game Settings → Manage Modules**.
+
+### Manual install
+1. Clone or download this repository into the `modules` directory of your Foundry VTT installation:
+   ```
+   git clone https://github.com/b34rblack-glitch/FoundryVTT-digitable-initiative-led
+   ```
 2. Restart your Foundry VTT server.
 
 ## Setup

--- a/lang/de.json
+++ b/lang/de.json
@@ -9,6 +9,20 @@
         "Name": "DM Platz Nummer",
         "Hint": "Auf welchem Platz sitzt der Dungeon Master?"
       },
+      "seat-config": {
+        "Name": "Platz-Konfiguration",
+        "Hint": "Lege fest, wie viele LEDs jedem Platz auf dem Streifen zugewiesen sind, und wähle die Farben für den aktuellen und den nächsten Kämpfer.",
+        "Label": "Plätze konfigurieren",
+        "Title": "DigiTable - Platz-Konfiguration",
+        "SeatHeader": "Platz",
+        "LedCount": "LED-Anzahl",
+        "ColorCurrent": "Farbe für aktuellen Zug",
+        "ColorNext": "Farbe für nächsten Zug",
+        "AddSeat": "Platz hinzufügen",
+        "RemoveSeat": "Platz entfernen",
+        "TotalLeds": "LEDs gesamt",
+        "Reset": "Zurücksetzen"
+      },
       "Actor": {
         "Title": "Charakter Einstellungen",
         "Seat": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,6 +9,20 @@
         "Name": "DM Seat ID",
         "Hint": "On which seat is the dungeon master?"
       },
+      "seat-config": {
+        "Name": "Seat configuration",
+        "Hint": "Assign how many LEDs each seat occupies on the strip, and pick the colors used to highlight the current and on-deck combatants.",
+        "Label": "Configure seats",
+        "Title": "DigiTable - Seat configuration",
+        "SeatHeader": "Seat",
+        "LedCount": "LED count",
+        "ColorCurrent": "Current turn color",
+        "ColorNext": "Next turn color",
+        "AddSeat": "Add seat",
+        "RemoveSeat": "Remove seat",
+        "TotalLeds": "Total LEDs",
+        "Reset": "Reset to defaults"
+      },
       "Actor": {
         "Title": "Character settings",
         "Seat": {
@@ -18,7 +32,7 @@
     },
     "Button": {
       "Save": "Save",
-      "Chancel": "Chancel"
+      "Chancel": "Cancel"
     }
   }
 }

--- a/module.json
+++ b/module.json
@@ -13,6 +13,9 @@
   "styles": [
     "styles/digitable-initiative-led.css"
   ],
+  "templates": [
+    "templates/seat-config.hbs"
+  ],
   "languages": [
     {
       "lang": "en",
@@ -31,6 +34,6 @@
   },
   "url": "https://github.com/mcules/FoundryVTT-digitable-initiative-led",
   "manifest": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/raw/main/module.json",
-  "version": "1.1.0",
-  "download": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/archive/refs/tags/v1.1.0.zip"
+  "version": "1.2.0",
+  "download": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/archive/refs/tags/v1.2.0.zip"
 }

--- a/module.json
+++ b/module.json
@@ -4,11 +4,14 @@
   "description": "This module controls the inititive LEDs on our digital table",
   "authors": [
     {
-    "name": "McUles"
+      "name": "McUles"
     }
-    ],
+  ],
   "scripts": [
     "scripts/digitable-initiative-led.js"
+  ],
+  "styles": [
+    "styles/digitable-initiative-led.css"
   ],
   "languages": [
     {
@@ -23,10 +26,11 @@
     }
   ],
   "compatibility": {
-    "verified": "11"
+    "minimum": "12",
+    "verified": "14"
   },
   "url": "https://github.com/mcules/FoundryVTT-digitable-initiative-led",
   "manifest": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/raw/main/module.json",
-  "version": "1.0.3",
-  "download": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/archive/refs/tags/v1.0.3.zip"
+  "version": "1.1.0",
+  "download": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/archive/refs/tags/v1.1.0.zip"
 }

--- a/module.json
+++ b/module.json
@@ -32,8 +32,8 @@
     "minimum": "12",
     "verified": "14"
   },
-  "url": "https://github.com/mcules/FoundryVTT-digitable-initiative-led",
-  "manifest": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/raw/main/module.json",
+  "url": "https://github.com/b34rblack-glitch/FoundryVTT-digitable-initiative-led",
+  "manifest": "https://github.com/b34rblack-glitch/FoundryVTT-digitable-initiative-led/raw/claude/foundry-vtt-v14-update-HsRfq/module.json",
   "version": "1.2.0",
-  "download": "https://github.com/mcules/FoundryVTT-digitable-initiative-led/archive/refs/tags/v1.2.0.zip"
+  "download": "https://github.com/b34rblack-glitch/FoundryVTT-digitable-initiative-led/archive/refs/heads/claude/foundry-vtt-v14-update-HsRfq.zip"
 }

--- a/scripts/digitable-initiative-led.js
+++ b/scripts/digitable-initiative-led.js
@@ -1,161 +1,238 @@
 /**
- * Digital Table System
- * @typedef {Object} DigiTableInitiativeLED
- * @property {string} id - A unique ID to identify this table.
- * @property {string} label - The text of the todo.
- * @property {boolean} isDone - Marks whether the todo is done.
- * @property {string} userId - The user who owns this todo.
+ * Digital Table - Initiative LED
+ * Controls the initiative LEDs of a physical "digital" table via the WLED JSON API.
  */
-class DigiTableInitiativeLED  {
-  static ID = 'FoundryVTT-digitable-initiative-led';
-  static initialize() {
-    this.settings();
-    this.seats_power = {
-      0: {"on":false,"bri":255},
-      1: {"on":true,"bri":255}
-    };
-    this.seats_off = {"seg":{"i":[[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0]]}};
-    this.seats = {
-      0: {"seg":{"i":[[255,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0]]}},
-      1: {"seg":{"i":[[0,0,0],[255,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0]]}},
-      2: {"seg":{"i":[[0,0,0],[0,0,0],[255,0,0],[0,0,0],[0,0,0],[0,0,0]]}},
-      3: {"seg":{"i":[[0,0,0],[0,0,0],[0,0,0],[255,0,0],[0,0,0],[0,0,0]]}},
-      4: {"seg":{"i":[[0,0,0],[0,0,0],[0,0,0],[0,0,0],[255,0,0],[0,0,0]]}},
-      5: {"seg":{"i":[[0,0,0],[0,0,0],[0,0,0],[0,0,0],[0,0,0],[255,0,0]]}}
-    };
-  }
-  static set_actor_led(actorId) {
-    let seatId = game.settings.get("FoundryVTT-digitable-initiative-led", 'actor-seats')[actorId];
-    if (seatId === undefined) {
-      seatId = 0;
-    }
+class DigiTableInitiativeLED {
+  static ID = 'foundryvtt-digitable-initiative-led';
 
-    this.httpPost(game.settings.get(this.ID, 'wled-uri'), this.seats[seatId]);
+  // i18n namespace used inside the lang files
+  static I18N = 'FoundryVTT-digitable-initiative-led';
+
+  static seats_power = {
+    0: { on: false, bri: 255 },
+    1: { on: true, bri: 255 }
+  };
+
+  static seats_off = { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } };
+
+  static seats = {
+    0: { seg: { i: [[255, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } },
+    1: { seg: { i: [[0, 0, 0], [255, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } },
+    2: { seg: { i: [[0, 0, 0], [0, 0, 0], [255, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } },
+    3: { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [255, 0, 0], [0, 0, 0], [0, 0, 0]] } },
+    4: { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [255, 0, 0], [0, 0, 0]] } },
+    5: { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [255, 0, 0]] } }
+  };
+
+  static initialize() {
+    this.registerSettings();
   }
+
+  static getWledUri() {
+    const ip = game.settings.get(this.ID, 'wled-ip');
+    if (!ip) return null;
+    return `http://${ip}/json`;
+  }
+
+  static set_actor_led(actorId) {
+    const uri = this.getWledUri();
+    if (!uri) return;
+    const seats = game.settings.get(this.ID, 'actor-seats') ?? {};
+    let seatId = seats[actorId];
+    if (seatId === undefined) seatId = 0;
+    this.httpPost(uri, this.seats[seatId]);
+  }
+
   static startInitiative() {
-    this.httpPost(game.settings.get(this.ID, 'wled-uri'), this.seats_power[1]).then();
-    this.httpPost(game.settings.get(this.ID, 'wled-uri'), this.seats_off).then();
+    const uri = this.getWledUri();
+    if (!uri) return;
+    this.httpPost(uri, this.seats_power[1]);
+    this.httpPost(uri, this.seats_off);
   }
+
   static stopInitiative() {
-    this.httpPost(game.settings.get(this.ID, 'wled-uri'), this.seats_power[0]).then();
+    const uri = this.getWledUri();
+    if (!uri) return;
+    this.httpPost(uri, this.seats_power[0]);
   }
+
   static async httpPost(url, values) {
     try {
       const response = await fetch(url, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(values),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(values)
       });
       if (!response.ok) {
         throw new Error(`Error during POST request: ${response.statusText}`);
       }
     } catch (error) {
-      console.error('Error:', error.message);
+      console.error(`${this.ID} |`, error.message);
     }
   }
-  static settings() {
-    // Set wled-ip
-    game.settings.register(this.ID, "wled-ip", {
-      name: this.ID + `.settings.wled-ip.Name`,
-      hint: this.ID + `.settings.wled-ip.Hint`,
+
+  static registerSettings() {
+    game.settings.register(this.ID, 'wled-ip', {
+      name: `${this.I18N}.settings.wled-ip.Name`,
+      hint: `${this.I18N}.settings.wled-ip.Hint`,
       scope: 'world',
       config: true,
       type: String,
-      default: "",
-      onChange: value => {
-        game.settings.set(this.ID, 'wled-uri', "http://" + value + "/json");
-      },
+      default: ''
     });
 
-    // Set wled-uri
-    game.settings.register(this.ID, "wled-uri", {
-      scope: 'world',
-      config: false,
-      type: String,
-      default: "http://" + game.settings.get(this.ID, 'wled-ip') + "/json",
-    });
-
-    // Set DM Seat ID
-    game.settings.register(this.ID, "dm-seat", {
-      name: this.ID + `.settings.dm-seat.Name`,
-      hint: this.ID + `.settings.dm-seat.Hint`,
+    game.settings.register(this.ID, 'dm-seat', {
+      name: `${this.I18N}.settings.dm-seat.Name`,
+      hint: `${this.I18N}.settings.dm-seat.Hint`,
       scope: 'world',
       config: true,
       type: Number,
-      default: 0,
+      default: 0
     });
 
-    // This setting includes the assignment of characters and seats
-    game.settings.register(this.ID, "actor-seats", {
+    game.settings.register(this.ID, 'actor-seats', {
       scope: 'world',
       config: false,
       type: Object,
       default: {}
     });
   }
-}
-Hooks.once('devModeReady', ({ registerPackageDebugFlag }) => {
-  registerPackageDebugFlag(DigiTableInitiativeLED .ID);
-});
-Hooks.once('init', () => {
-  DigiTableInitiativeLED .initialize();
-});
-Hooks.on('renderActorDirectory', (app, html) => {
-  // check if current user is Game Master
-  if (game.user.isGM) {
-    const btnSettings = $(`<button type='button' class='digitable-initiative-led-button flex0' title="${tooltip}"><i class='fa-solid fa-hand-fist'></i></button>`);
-    html.find(".directory-list .actor").append(btnSettings);
-    html.on('click', '.digitable-initiative-led-button', (event) => {
-      const actorId = event.currentTarget.closest('.actor').dataset.documentId
-      let applyChanges = false;
-      let current_seat = game.settings.get("FoundryVTT-digitable-initiative-led", 'actor-seats')[actorId];
-      if (current_seat === undefined) {
-        current_seat = 0;
-      }
 
-      new Dialog({
-        title: game.i18n.localize("FoundryVTT-digitable-initiative-led.settings.Actor.Title"),
-        content: `
-    <form>
-      <div class="form-group">
-        <label>`+ game.i18n.localize("FoundryVTT-digitable-initiative-led.settings.Actor.Seat.Name") +`:</label>
-        <input type='text' name='seatID' value="`+ current_seat +`">
-      </div>
-    </form>`,
-        buttons: {
-          yes: {
-            icon: "<i class='fas fa-check'></i>",
-            label: game.i18n.localize("FoundryVTT-digitable-initiative-led.Button.Save"),
-            callback: () => applyChanges = true
-          },
-          no: {
-            icon: "<i class='fas fa-times'></i>",
-            label: game.i18n.localize("FoundryVTT-digitable-initiative-led.Button.Chancel")
-          },
+  /**
+   * Open the per-actor seat-assignment dialog using DialogV2 (v13+).
+   * Falls back to the legacy Dialog on Foundry v12.
+   */
+  static async openActorSeatDialog(actorId) {
+    const seats = game.settings.get(this.ID, 'actor-seats') ?? {};
+    const current = seats[actorId] ?? 0;
+
+    const title = game.i18n.localize(`${this.I18N}.settings.Actor.Title`);
+    const seatLabel = game.i18n.localize(`${this.I18N}.settings.Actor.Seat.Name`);
+    const saveLabel = game.i18n.localize(`${this.I18N}.Button.Save`);
+    const cancelLabel = game.i18n.localize(`${this.I18N}.Button.Chancel`);
+
+    const content = `
+      <form>
+        <div class="form-group">
+          <label>${seatLabel}:</label>
+          <input type="text" name="seatID" value="${current}">
+        </div>
+      </form>`;
+
+    const DialogV2 = foundry?.applications?.api?.DialogV2;
+    if (DialogV2) {
+      const result = await DialogV2.prompt({
+        window: { title },
+        content,
+        ok: {
+          icon: 'fas fa-check',
+          label: saveLabel,
+          callback: (_event, button) => button.form.elements.seatID.value
         },
-        default: "no",
-        close: html => {
-          if (applyChanges) {
-            let seatID = html.find('[name=seatID]')[0].value || "none";
-            let actor_seats = game.settings.get("FoundryVTT-digitable-initiative-led", 'actor-seats');
-            actor_seats[actorId] = seatID;
-            game.settings.set("FoundryVTT-digitable-initiative-led", 'actor-seats', actor_seats);
-          }
+        rejectClose: false
+      }).catch(() => null);
+
+      if (result === null || result === undefined) return;
+      const updated = game.settings.get(this.ID, 'actor-seats') ?? {};
+      updated[actorId] = result || 'none';
+      await game.settings.set(this.ID, 'actor-seats', updated);
+      return;
+    }
+
+    // Legacy fallback (Foundry v12)
+    let applyChanges = false;
+    new Dialog({
+      title,
+      content,
+      buttons: {
+        yes: {
+          icon: "<i class='fas fa-check'></i>",
+          label: saveLabel,
+          callback: () => { applyChanges = true; }
+        },
+        no: {
+          icon: "<i class='fas fa-times'></i>",
+          label: cancelLabel
         }
-      }).render(true);
+      },
+      default: 'no',
+      close: (html) => {
+        if (!applyChanges) return;
+        const input = html[0]?.querySelector?.('[name=seatID]') ?? html.find('[name=seatID]')[0];
+        const seatID = input?.value || 'none';
+        const updated = game.settings.get(this.ID, 'actor-seats') ?? {};
+        updated[actorId] = seatID;
+        game.settings.set(this.ID, 'actor-seats', updated);
+      }
+    }).render(true);
+  }
+
+  /**
+   * Inject a button into every actor entry in the Actor Directory.
+   * Works against both the jQuery wrapper (v12) and the bare HTMLElement (v13+).
+   */
+  static onRenderActorDirectory(app, html) {
+    if (!game.user.isGM) return;
+
+    const root = html instanceof HTMLElement
+      ? html
+      : (html?.[0] ?? html);
+    if (!root || typeof root.querySelectorAll !== 'function') return;
+
+    const tooltip = game.i18n.localize(`${this.I18N}.settings.Actor.Title`);
+    const iconHTML = `<button type="button" class="digitable-initiative-led-button flex0" data-tooltip="${tooltip}" title="${tooltip}"><i class="fa-solid fa-hand-fist"></i></button>`;
+
+    // v13+ uses .directory-item; v12 uses .actor. Cover both.
+    const entries = root.querySelectorAll(
+      '.directory-list .directory-item.actor, .directory-list .directory-item[data-entry-id], .directory-list li.actor'
+    );
+
+    entries.forEach((entry) => {
+      if (entry.querySelector(':scope > .digitable-initiative-led-button')) return;
+      entry.insertAdjacentHTML('beforeend', iconHTML);
+    });
+
+    if (root.dataset.digitableInitBound === '1') return;
+    root.dataset.digitableInitBound = '1';
+
+    root.addEventListener('click', (event) => {
+      const btn = event.target.closest('.digitable-initiative-led-button');
+      if (!btn) return;
+      event.preventDefault();
+      event.stopPropagation();
+
+      const entry = btn.closest('[data-entry-id], [data-document-id], .actor');
+      const actorId = entry?.dataset.entryId ?? entry?.dataset.documentId;
+      if (!actorId) return;
+
+      DigiTableInitiativeLED.openActorSeatDialog(actorId);
     });
   }
+}
+
+Hooks.once('init', () => {
+  DigiTableInitiativeLED.initialize();
 });
-Hooks.on("updateCombat", (combat, data) => {
-  if (data.turn !== undefined && data.turn !== combat.previous.turn) {
-    DigiTableInitiativeLED.set_actor_led(combat.combatant.actorId);
-  }
+
+Hooks.once('devModeReady', ({ registerPackageDebugFlag }) => {
+  registerPackageDebugFlag(DigiTableInitiativeLED.ID);
 });
-Hooks.on("deleteCombat", (combat) => {
+
+Hooks.on('renderActorDirectory', (app, html) => {
+  DigiTableInitiativeLED.onRenderActorDirectory(app, html);
+});
+
+Hooks.on('updateCombat', (combat, change) => {
+  if (change.turn === undefined) return;
+  const actorId = combat.combatant?.actorId;
+  if (!actorId) return;
+  DigiTableInitiativeLED.set_actor_led(actorId);
+});
+
+Hooks.on('deleteCombat', () => {
   DigiTableInitiativeLED.stopInitiative();
 });
-Hooks.on("createCombat", (combat) => {
+
+Hooks.on('createCombat', () => {
   DigiTableInitiativeLED.startInitiative();
 });

--- a/scripts/digitable-initiative-led.js
+++ b/scripts/digitable-initiative-led.js
@@ -1,75 +1,31 @@
 /**
  * Digital Table - Initiative LED
- * Controls the initiative LEDs of a physical "digital" table via the WLED JSON API.
+ * Controls a WLED-driven LED strip from Foundry combat events.
+ * Each "seat" owns a contiguous range of LEDs. During combat, the
+ * active combatant's seat is lit with the "current" color and the
+ * next combatant's seat is lit with the "next" color.
  */
 class DigiTableInitiativeLED {
   static ID = 'foundryvtt-digitable-initiative-led';
-
-  // i18n namespace used inside the lang files
   static I18N = 'FoundryVTT-digitable-initiative-led';
 
-  static seats_power = {
-    0: { on: false, bri: 255 },
-    1: { on: true, bri: 255 }
-  };
+  static DEFAULT_SEATS = [
+    { ledCount: 1 },
+    { ledCount: 1 },
+    { ledCount: 1 },
+    { ledCount: 1 },
+    { ledCount: 1 },
+    { ledCount: 1 }
+  ];
 
-  static seats_off = { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } };
-
-  static seats = {
-    0: { seg: { i: [[255, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } },
-    1: { seg: { i: [[0, 0, 0], [255, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } },
-    2: { seg: { i: [[0, 0, 0], [0, 0, 0], [255, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0]] } },
-    3: { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [255, 0, 0], [0, 0, 0], [0, 0, 0]] } },
-    4: { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [255, 0, 0], [0, 0, 0]] } },
-    5: { seg: { i: [[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0], [255, 0, 0]] } }
-  };
+  static DEFAULT_COLOR_CURRENT = '#ff0000';
+  static DEFAULT_COLOR_NEXT = '#ffff00';
 
   static initialize() {
     this.registerSettings();
   }
 
-  static getWledUri() {
-    const ip = game.settings.get(this.ID, 'wled-ip');
-    if (!ip) return null;
-    return `http://${ip}/json`;
-  }
-
-  static set_actor_led(actorId) {
-    const uri = this.getWledUri();
-    if (!uri) return;
-    const seats = game.settings.get(this.ID, 'actor-seats') ?? {};
-    let seatId = seats[actorId];
-    if (seatId === undefined) seatId = 0;
-    this.httpPost(uri, this.seats[seatId]);
-  }
-
-  static startInitiative() {
-    const uri = this.getWledUri();
-    if (!uri) return;
-    this.httpPost(uri, this.seats_power[1]);
-    this.httpPost(uri, this.seats_off);
-  }
-
-  static stopInitiative() {
-    const uri = this.getWledUri();
-    if (!uri) return;
-    this.httpPost(uri, this.seats_power[0]);
-  }
-
-  static async httpPost(url, values) {
-    try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(values)
-      });
-      if (!response.ok) {
-        throw new Error(`Error during POST request: ${response.statusText}`);
-      }
-    } catch (error) {
-      console.error(`${this.ID} |`, error.message);
-    }
-  }
+  // ---- Settings ---------------------------------------------------------
 
   static registerSettings() {
     game.settings.register(this.ID, 'wled-ip', {
@@ -96,12 +52,170 @@ class DigiTableInitiativeLED {
       type: Object,
       default: {}
     });
+
+    game.settings.register(this.ID, 'seat-config', {
+      scope: 'world',
+      config: false,
+      type: Object,
+      default: { seats: this.DEFAULT_SEATS }
+    });
+
+    game.settings.register(this.ID, 'color-current', {
+      scope: 'world',
+      config: false,
+      type: String,
+      default: this.DEFAULT_COLOR_CURRENT
+    });
+
+    game.settings.register(this.ID, 'color-next', {
+      scope: 'world',
+      config: false,
+      type: String,
+      default: this.DEFAULT_COLOR_NEXT
+    });
+
+    game.settings.registerMenu(this.ID, 'seat-config-menu', {
+      name: `${this.I18N}.settings.seat-config.Name`,
+      label: `${this.I18N}.settings.seat-config.Label`,
+      hint: `${this.I18N}.settings.seat-config.Hint`,
+      icon: 'fa-solid fa-sliders',
+      type: SeatConfigApp,
+      restricted: true
+    });
+  }
+
+  // ---- WLED helpers -----------------------------------------------------
+
+  static getWledUri() {
+    const ip = game.settings.get(this.ID, 'wled-ip');
+    if (!ip) return null;
+    return `http://${ip}/json`;
+  }
+
+  static async httpPost(payload) {
+    const url = this.getWledUri();
+    if (!url) return;
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!response.ok) {
+        throw new Error(`Error during POST request: ${response.statusText}`);
+      }
+    } catch (error) {
+      console.error(`${this.ID} |`, error.message);
+    }
   }
 
   /**
-   * Open the per-actor seat-assignment dialog using DialogV2 (v13+).
-   * Falls back to the legacy Dialog on Foundry v12.
+   * Convert a "#rrggbb" string to a [r, g, b] triple.
    */
+  static hexToRgb(hex) {
+    const ColorCls = foundry?.utils?.Color;
+    if (ColorCls?.fromString) {
+      const c = ColorCls.fromString(hex);
+      if (c?.rgb) return c.rgb.map((v) => Math.round(v * 255));
+    }
+    const m = /^#?([0-9a-f]{6})$/i.exec(hex ?? '');
+    if (!m) return [0, 0, 0];
+    const n = parseInt(m[1], 16);
+    return [(n >> 16) & 0xff, (n >> 8) & 0xff, n & 0xff];
+  }
+
+  /**
+   * Build prefix-sum ranges for every seat. Returns
+   * `{ total, ranges: [{start, end}, ...] }` where `end` is exclusive.
+   */
+  static buildSeatRanges() {
+    const cfg = game.settings.get(this.ID, 'seat-config') ?? {};
+    const seats = Array.isArray(cfg.seats) ? cfg.seats : [];
+    const ranges = [];
+    let cursor = 0;
+    for (const seat of seats) {
+      const count = Math.max(0, Number(seat?.ledCount ?? 0) | 0);
+      ranges.push({ start: cursor, end: cursor + count });
+      cursor += count;
+    }
+    return { total: cursor, ranges };
+  }
+
+  /**
+   * Locate the seat index assigned to a given actor, or null.
+   */
+  static seatForActor(actorId) {
+    if (!actorId) return null;
+    const seats = game.settings.get(this.ID, 'actor-seats') ?? {};
+    const raw = seats[actorId];
+    if (raw === undefined || raw === null || raw === 'none') return null;
+    const idx = Number(raw);
+    return Number.isInteger(idx) && idx >= 0 ? idx : null;
+  }
+
+  /**
+   * Resolve the "next" combatant, skipping the current one and any
+   * defeated combatants. Falls back to scanning `combat.turns` when
+   * `Combat#nextCombatant` is unavailable.
+   */
+  static resolveNextCombatant(combat) {
+    if (!combat) return null;
+    if (combat.nextCombatant) return combat.nextCombatant;
+
+    const turns = combat.turns ?? [];
+    if (!turns.length) return null;
+    const start = (combat.turn ?? -1) + 1;
+    for (let i = 0; i < turns.length; i += 1) {
+      const c = turns[(start + i) % turns.length];
+      if (c && !c.isDefeated && c !== combat.combatant) return c;
+    }
+    return null;
+  }
+
+  // ---- Rendering --------------------------------------------------------
+
+  /**
+   * Compute and send the current frame for an in-progress combat.
+   */
+  static refresh(combat) {
+    const { total, ranges } = this.buildSeatRanges();
+    if (total <= 0) {
+      this.httpPost({ on: true, bri: 255, seg: { i: [] } });
+      return;
+    }
+
+    const ledArray = Array.from({ length: total }, () => [0, 0, 0]);
+
+    const currentSeat = this.seatForActor(combat?.combatant?.actorId);
+    const nextSeat = this.seatForActor(this.resolveNextCombatant(combat)?.actorId);
+    const currentColor = this.hexToRgb(game.settings.get(this.ID, 'color-current'));
+    const nextColor = this.hexToRgb(game.settings.get(this.ID, 'color-next'));
+
+    const paint = (seatIdx, color) => {
+      if (seatIdx === null || seatIdx < 0 || seatIdx >= ranges.length) return;
+      const { start, end } = ranges[seatIdx];
+      for (let i = start; i < end; i += 1) ledArray[i] = color;
+    };
+
+    // Paint "next" first so that if a single seat is both, "current" wins.
+    paint(nextSeat, nextColor);
+    paint(currentSeat, currentColor);
+
+    this.httpPost({ on: true, bri: 255, seg: { i: ledArray } });
+  }
+
+  static startCombat() {
+    const { total } = this.buildSeatRanges();
+    const off = Array.from({ length: total }, () => [0, 0, 0]);
+    this.httpPost({ on: true, bri: 255, seg: { i: off } });
+  }
+
+  static stopCombat() {
+    this.httpPost({ on: false });
+  }
+
+  // ---- Actor → seat assignment dialog ----------------------------------
+
   static async openActorSeatDialog(actorId) {
     const seats = game.settings.get(this.ID, 'actor-seats') ?? {};
     const current = seats[actorId] ?? 0;
@@ -115,7 +229,7 @@ class DigiTableInitiativeLED {
       <form>
         <div class="form-group">
           <label>${seatLabel}:</label>
-          <input type="text" name="seatID" value="${current}">
+          <input type="number" min="0" step="1" name="seatID" value="${current}">
         </div>
       </form>`;
 
@@ -134,12 +248,12 @@ class DigiTableInitiativeLED {
 
       if (result === null || result === undefined) return;
       const updated = game.settings.get(this.ID, 'actor-seats') ?? {};
-      updated[actorId] = result || 'none';
+      updated[actorId] = result === '' ? 'none' : result;
       await game.settings.set(this.ID, 'actor-seats', updated);
       return;
     }
 
-    // Legacy fallback (Foundry v12)
+    // Legacy v12 fallback
     let applyChanges = false;
     new Dialog({
       title,
@@ -167,22 +281,17 @@ class DigiTableInitiativeLED {
     }).render(true);
   }
 
-  /**
-   * Inject a button into every actor entry in the Actor Directory.
-   * Works against both the jQuery wrapper (v12) and the bare HTMLElement (v13+).
-   */
+  // ---- Actor Directory button ------------------------------------------
+
   static onRenderActorDirectory(app, html) {
     if (!game.user.isGM) return;
 
-    const root = html instanceof HTMLElement
-      ? html
-      : (html?.[0] ?? html);
+    const root = html instanceof HTMLElement ? html : (html?.[0] ?? html);
     if (!root || typeof root.querySelectorAll !== 'function') return;
 
     const tooltip = game.i18n.localize(`${this.I18N}.settings.Actor.Title`);
     const iconHTML = `<button type="button" class="digitable-initiative-led-button flex0" data-tooltip="${tooltip}" title="${tooltip}"><i class="fa-solid fa-hand-fist"></i></button>`;
 
-    // v13+ uses .directory-item; v12 uses .actor. Cover both.
     const entries = root.querySelectorAll(
       '.directory-list .directory-item.actor, .directory-list .directory-item[data-entry-id], .directory-list li.actor'
     );
@@ -210,6 +319,224 @@ class DigiTableInitiativeLED {
   }
 }
 
+/**
+ * SeatConfigApp - GM-facing form for configuring how many LEDs each
+ * seat owns and the colors used for the current/next combatant.
+ *
+ * Uses ApplicationV2 + HandlebarsApplicationMixin when available
+ * (Foundry v12+); falls back to a legacy FormApplication on older cores.
+ */
+const _AppV2 = foundry?.applications?.api?.ApplicationV2;
+const _HbsMixin = foundry?.applications?.api?.HandlebarsApplicationMixin;
+
+class SeatConfigApp extends (_AppV2 && _HbsMixin ? _HbsMixin(_AppV2) : FormApplication) {
+  constructor(options = {}) {
+    super(options);
+    this._working = this._loadFromSettings();
+  }
+
+  // ---- ApplicationV2 surface -------------------------------------------
+
+  static DEFAULT_OPTIONS = {
+    id: 'digitable-seat-config',
+    tag: 'form',
+    window: {
+      title: 'FoundryVTT-digitable-initiative-led.settings.seat-config.Title',
+      icon: 'fa-solid fa-sliders',
+      contentClasses: ['standard-form', 'digitable-seat-config']
+    },
+    position: { width: 480, height: 'auto' },
+    form: {
+      handler: SeatConfigApp._onSubmit,
+      closeOnSubmit: true,
+      submitOnChange: false
+    },
+    actions: {
+      addSeat: SeatConfigApp._onAddSeat,
+      removeSeat: SeatConfigApp._onRemoveSeat,
+      reset: SeatConfigApp._onReset
+    }
+  };
+
+  static PARTS = {
+    body: { template: 'modules/foundryvtt-digitable-initiative-led/templates/seat-config.hbs' }
+  };
+
+  // ---- Legacy FormApplication surface (v11/early-v12 fallback) ---------
+
+  static get defaultOptions() {
+    const base = (super.defaultOptions ?? {});
+    return foundry.utils.mergeObject(base, {
+      id: 'digitable-seat-config',
+      title: game.i18n?.localize?.('FoundryVTT-digitable-initiative-led.settings.seat-config.Title') ?? 'Seat configuration',
+      template: 'modules/foundryvtt-digitable-initiative-led/templates/seat-config.hbs',
+      width: 480,
+      height: 'auto',
+      closeOnSubmit: true,
+      submitOnClose: false
+    });
+  }
+
+  // ---- Data plumbing ---------------------------------------------------
+
+  _loadFromSettings() {
+    const cfg = game.settings.get(DigiTableInitiativeLED.ID, 'seat-config') ?? {};
+    const seats = Array.isArray(cfg.seats) && cfg.seats.length
+      ? cfg.seats.map((s) => ({ ledCount: Math.max(0, Number(s?.ledCount ?? 0) | 0) }))
+      : DigiTableInitiativeLED.DEFAULT_SEATS.map((s) => ({ ...s }));
+    return {
+      seats,
+      colorCurrent: game.settings.get(DigiTableInitiativeLED.ID, 'color-current') || DigiTableInitiativeLED.DEFAULT_COLOR_CURRENT,
+      colorNext: game.settings.get(DigiTableInitiativeLED.ID, 'color-next') || DigiTableInitiativeLED.DEFAULT_COLOR_NEXT
+    };
+  }
+
+  _captureFormState(form) {
+    if (!form) return;
+    const counts = form.querySelectorAll('input[name^="seats."]');
+    const seats = [];
+    counts.forEach((input) => {
+      const m = /^seats\.(\d+)\.ledCount$/.exec(input.name);
+      if (!m) return;
+      const idx = Number(m[1]);
+      seats[idx] = { ledCount: Math.max(0, Number(input.value) | 0) };
+    });
+    this._working.seats = seats.filter((s) => s);
+    const cc = form.querySelector('input[name="colorCurrent"]');
+    const cn = form.querySelector('input[name="colorNext"]');
+    if (cc) this._working.colorCurrent = cc.value || DigiTableInitiativeLED.DEFAULT_COLOR_CURRENT;
+    if (cn) this._working.colorNext = cn.value || DigiTableInitiativeLED.DEFAULT_COLOR_NEXT;
+  }
+
+  // ApplicationV2 data hook
+  async _prepareContext(_options) {
+    return this._buildContext();
+  }
+
+  // FormApplication legacy data hook
+  async getData(_options) {
+    return this._buildContext();
+  }
+
+  _buildContext() {
+    const total = this._working.seats.reduce((a, s) => a + Math.max(0, Number(s.ledCount) | 0), 0);
+    return {
+      seats: this._working.seats.map((s, i) => ({ index: i, ledCount: s.ledCount })),
+      colorCurrent: this._working.colorCurrent,
+      colorNext: this._working.colorNext,
+      total,
+      i18n: {
+        title: `${DigiTableInitiativeLED.I18N}.settings.seat-config.Title`,
+        seatHeader: `${DigiTableInitiativeLED.I18N}.settings.seat-config.SeatHeader`,
+        ledCount: `${DigiTableInitiativeLED.I18N}.settings.seat-config.LedCount`,
+        colorCurrent: `${DigiTableInitiativeLED.I18N}.settings.seat-config.ColorCurrent`,
+        colorNext: `${DigiTableInitiativeLED.I18N}.settings.seat-config.ColorNext`,
+        addSeat: `${DigiTableInitiativeLED.I18N}.settings.seat-config.AddSeat`,
+        removeSeat: `${DigiTableInitiativeLED.I18N}.settings.seat-config.RemoveSeat`,
+        total: `${DigiTableInitiativeLED.I18N}.settings.seat-config.TotalLeds`,
+        save: `${DigiTableInitiativeLED.I18N}.Button.Save`,
+        cancel: `${DigiTableInitiativeLED.I18N}.Button.Chancel`,
+        reset: `${DigiTableInitiativeLED.I18N}.settings.seat-config.Reset`
+      }
+    };
+  }
+
+  // ---- Actions ---------------------------------------------------------
+
+  static _onAddSeat(event) {
+    event?.preventDefault?.();
+    this._captureFormState(this.element);
+    this._working.seats.push({ ledCount: 1 });
+    this.render();
+  }
+
+  static _onRemoveSeat(event, target) {
+    event?.preventDefault?.();
+    this._captureFormState(this.element);
+    const idx = Number(target?.dataset?.seatIndex);
+    if (!Number.isInteger(idx)) return;
+    this._working.seats.splice(idx, 1);
+    this.render();
+  }
+
+  static _onReset(event) {
+    event?.preventDefault?.();
+    this._working = {
+      seats: DigiTableInitiativeLED.DEFAULT_SEATS.map((s) => ({ ...s })),
+      colorCurrent: DigiTableInitiativeLED.DEFAULT_COLOR_CURRENT,
+      colorNext: DigiTableInitiativeLED.DEFAULT_COLOR_NEXT
+    };
+    this.render();
+  }
+
+  // ApplicationV2 submit
+  static async _onSubmit(_event, _form, formData) {
+    const data = formData?.object ?? {};
+    await this._persist(data);
+  }
+
+  // FormApplication submit
+  async _updateObject(_event, formData) {
+    await this._persist(formData);
+  }
+
+  async _persist(formData) {
+    const seats = [];
+    for (const [key, value] of Object.entries(formData ?? {})) {
+      const m = /^seats\.(\d+)\.ledCount$/.exec(key);
+      if (!m) continue;
+      seats[Number(m[1])] = { ledCount: Math.max(0, Number(value) | 0) };
+    }
+    const cleaned = seats.filter((s) => s);
+
+    await game.settings.set(DigiTableInitiativeLED.ID, 'seat-config', {
+      seats: cleaned.length ? cleaned : DigiTableInitiativeLED.DEFAULT_SEATS.map((s) => ({ ...s }))
+    });
+    await game.settings.set(
+      DigiTableInitiativeLED.ID,
+      'color-current',
+      formData?.colorCurrent || DigiTableInitiativeLED.DEFAULT_COLOR_CURRENT
+    );
+    await game.settings.set(
+      DigiTableInitiativeLED.ID,
+      'color-next',
+      formData?.colorNext || DigiTableInitiativeLED.DEFAULT_COLOR_NEXT
+    );
+  }
+
+  // Re-bind on each ApplicationV2 render so live totals reflect input.
+  _onRender(context, options) {
+    if (typeof super._onRender === 'function') super._onRender(context, options);
+    this._bindLiveTotal();
+  }
+
+  // Same for legacy FormApplication.
+  activateListeners(html) {
+    if (typeof super.activateListeners === 'function') super.activateListeners(html);
+    this.element = html[0] ?? html;
+    this._bindLiveTotal();
+  }
+
+  _bindLiveTotal() {
+    const root = this.element instanceof HTMLElement ? this.element : this.element?.[0];
+    if (!root) return;
+    const totalEl = root.querySelector('[data-total-leds]');
+    if (!totalEl) return;
+    const recompute = () => {
+      let total = 0;
+      root.querySelectorAll('input[name^="seats."]').forEach((i) => {
+        total += Math.max(0, Number(i.value) | 0);
+      });
+      totalEl.textContent = String(total);
+    };
+    root.querySelectorAll('input[name^="seats."]').forEach((i) => {
+      i.addEventListener('input', recompute);
+    });
+  }
+}
+
+// ---- Hooks --------------------------------------------------------------
+
 Hooks.once('init', () => {
   DigiTableInitiativeLED.initialize();
 });
@@ -222,17 +549,15 @@ Hooks.on('renderActorDirectory', (app, html) => {
   DigiTableInitiativeLED.onRenderActorDirectory(app, html);
 });
 
+Hooks.on('createCombat', () => {
+  DigiTableInitiativeLED.startCombat();
+});
+
 Hooks.on('updateCombat', (combat, change) => {
-  if (change.turn === undefined) return;
-  const actorId = combat.combatant?.actorId;
-  if (!actorId) return;
-  DigiTableInitiativeLED.set_actor_led(actorId);
+  if (!('turn' in change) && !('round' in change)) return;
+  DigiTableInitiativeLED.refresh(combat);
 });
 
 Hooks.on('deleteCombat', () => {
-  DigiTableInitiativeLED.stopInitiative();
-});
-
-Hooks.on('createCombat', () => {
-  DigiTableInitiativeLED.startInitiative();
+  DigiTableInitiativeLED.stopCombat();
 });

--- a/styles/digitable-initiative-led.css
+++ b/styles/digitable-initiative-led.css
@@ -30,3 +30,63 @@
     box-shadow: none;
     text-shadow: 0 0 5px red;
 }
+
+.digitable-seat-config .digitable-seat-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35em;
+    margin: 0.5em 0;
+}
+
+.digitable-seat-config .digitable-seat-row {
+    display: grid;
+    grid-template-columns: 6em 1fr auto;
+    align-items: center;
+    gap: 0.5em;
+}
+
+.digitable-seat-config .digitable-seat-label {
+    font-weight: bold;
+}
+
+.digitable-seat-config .digitable-seat-count {
+    width: 100%;
+}
+
+.digitable-seat-config .digitable-seat-remove {
+    background: transparent;
+    border: 0;
+    color: inherit;
+    cursor: pointer;
+    padding: 0.25em 0.5em;
+}
+
+.digitable-seat-config .digitable-seat-remove:hover {
+    color: var(--color-warm-2, #b00);
+}
+
+.digitable-seat-config .digitable-seat-actions {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0.5em 0;
+}
+
+.digitable-seat-config .digitable-seat-total strong {
+    font-variant-numeric: tabular-nums;
+}
+
+.digitable-seat-config .form-group input[type="color"] {
+    width: 4em;
+    height: 2em;
+    padding: 0;
+    border: 1px solid var(--color-border-light-tertiary, #999);
+    background: transparent;
+}
+
+.digitable-seat-config .digitable-seat-footer {
+    display: flex;
+    gap: 0.5em;
+    justify-content: flex-end;
+    margin-top: 0.5em;
+}

--- a/templates/seat-config.hbs
+++ b/templates/seat-config.hbs
@@ -1,0 +1,54 @@
+<section class="digitable-seat-config-body">
+  <p class="notes">{{localize i18n.title}}</p>
+
+  <div class="digitable-seat-list">
+    {{#each seats}}
+      <div class="digitable-seat-row" data-seat-index="{{this.index}}">
+        <label class="digitable-seat-label">{{localize ../i18n.seatHeader}} {{this.index}}</label>
+        <input type="number"
+               name="seats.{{this.index}}.ledCount"
+               value="{{this.ledCount}}"
+               min="0"
+               step="1"
+               class="digitable-seat-count" />
+        <button type="button"
+                class="digitable-seat-remove"
+                data-action="removeSeat"
+                data-seat-index="{{this.index}}"
+                data-tooltip="{{localize ../i18n.removeSeat}}">
+          <i class="fa-solid fa-trash"></i>
+        </button>
+      </div>
+    {{/each}}
+  </div>
+
+  <div class="digitable-seat-actions">
+    <button type="button" data-action="addSeat">
+      <i class="fa-solid fa-plus"></i> {{localize i18n.addSeat}}
+    </button>
+    <span class="digitable-seat-total">
+      {{localize i18n.total}}: <strong data-total-leds>{{total}}</strong>
+    </span>
+  </div>
+
+  <hr />
+
+  <div class="form-group">
+    <label>{{localize i18n.colorCurrent}}</label>
+    <input type="color" name="colorCurrent" value="{{colorCurrent}}" />
+  </div>
+
+  <div class="form-group">
+    <label>{{localize i18n.colorNext}}</label>
+    <input type="color" name="colorNext" value="{{colorNext}}" />
+  </div>
+</section>
+
+<footer class="form-footer digitable-seat-footer">
+  <button type="button" data-action="reset">
+    <i class="fa-solid fa-rotate-left"></i> {{localize i18n.reset}}
+  </button>
+  <button type="submit">
+    <i class="fa-solid fa-check"></i> {{localize i18n.save}}
+  </button>
+</footer>


### PR DESCRIPTION
- Replace deprecated Dialog class with DialogV2 (foundry.applications.api), with a Dialog fallback for v12.
- Rewrite renderActorDirectory handler to work with the v13+ bare HTMLElement (no jQuery), while still supporting the v12 jQuery wrapper.
- Use updated .directory-item selectors introduced with the v13 sidebar rewrite, and resolve actor IDs from data-entry-id / data-document-id.
- Lazily compute the WLED URI from the wled-ip setting instead of caching it in a second setting whose default tried to read another setting at registration time.
- Align the settings namespace with the lowercase module id from module.json so the two no longer disagree.
- Fix an undefined `tooltip` reference on the directory button.
- Register the existing stylesheet via module.json so it actually loads.
- Bump compatibility to minimum 12 / verified 14 and bump module version.